### PR TITLE
fixed incorrect width field for BFI

### DIFF
--- a/armv7.c
+++ b/armv7.c
@@ -496,7 +496,7 @@ static int armv7_disas_cond(darm_t *d, uint32_t w)
         // the bfi and bfc instructions specify the MSB, whereas the SBFX and
         // UBFX instructions specify the width minus one
         if(d->instr == I_BFI) {
-            d->width = ((w >> 16) & b11111) - d->lsb;
+            d->width = ((w >> 16) & b11111) - d->lsb + 1;
 
             // if Rn is 0b1111, then this is in fact the BFC instruction
             if(d->Rn == b1111) {


### PR DESCRIPTION
As per A8.8.20 of the manual describing BFI:
width: The number of bits to be copied, in the range `1` to `32-<lsb>`. The required value of `msbit` is `<lsb>+<width>-1`.

Hence `width = msb - lsb + 1`
