### PR TITLE
dropped reporting of mov[s] r0, r0 as NOP

### DIFF
--- a/armv7.c
+++ b/armv7.c
@@ -618,12 +618,6 @@ static int armv7_disas_cond(darm_t *d, uint32_t w)
             // actually a MOV instruction (there's no register-shifted LSL)
             if(d->instr == I_LSL && d->shift_type == S_LSL && d->shift == 0) {
                 d->instr = I_MOV;
-
-                // if Rd and Rm are zero, then this is a NOP instruction
-                if(d->Rd == 0 && d->Rm == 0) {
-                    d->instr = I_NOP;
-                    d->Rd = d->Rm = R_INVLD;
-                }
             }
 
             // if this is a ROR instruction with a zero shift, then it's


### PR DESCRIPTION
Currently `mov[s] r0, r0` is reported as a `I_NOP` but `movs` is different from a `nop` and can require special treatment.
Consider the following example from `libc` that shows how a `movs r0, r0` is useful.

```
ENTRY(gettid)
    .save   {r4, r7}
    stmfd   sp!, {r4, r7}
    ldr     r7, =__NR_gettid
    swi     #0
    ldmfd   sp!, {r4, r7}
    movs    r0, r0
    bxpl    lr
    b       __set_syscall_errno
```
