### PR TITLE
Python 3.x: Darm string representation returns a bytes object instead of...

### DIFF
--- a/darm.py
+++ b/darm.py
@@ -267,7 +267,7 @@ class Darm:
     def __str__(self):
         x = _DarmStr()
         if _lib.darm_str2(self.d, byref(x), True) == 0:
-            return x.total
+            return x.total.decode('ascii')
         return ''
 
 


### PR DESCRIPTION
... string object. Use decode method to conform with Python 2.x to return a string object.
